### PR TITLE
clearing bucket before deploying new contents

### DIFF
--- a/script/s3.js
+++ b/script/s3.js
@@ -37,7 +37,7 @@ const emptyBucket = (bucketName, callback) => {
     Bucket: bucketName
   };
 
-  uploader.listObjects(params, function(err, data) {
+  uploader.listObjectsV2(params, function(err, data) {
     if (err) return callback(err);
 
     if (data.Contents.length == 0) callback();


### PR DESCRIPTION
## Summary

Clear bucket before deploying new elements to S3. This allows us to keep the cache, but delete it when a new deploy is made.
Also changed `new Buffer()` for `Buffer.from()` as I was getting a bug, apparently `new Buffer()` is deprecated.

## GIF

![svl-react](https://user-images.githubusercontent.com/5349650/57804182-6e0d1f00-7730-11e9-8a46-d5493324f2af.gif)
