### PR TITLE
delete only files which start with prefix

### DIFF
--- a/script/s3.js
+++ b/script/s3.js
@@ -52,13 +52,14 @@ const findRegexOrString = (array, value) =>
 
 const emptyBucket = (bucketName, callback) => {
   let params = {
-    Bucket: bucketName
+    Bucket: bucketName,
+    Prefix: outputPath
   };
 
   uploader.listObjectsV2(params, (err, data) => {
     if (err) return callback(err);
 
-    if (data.Contents.length == 0) callback();
+    if (data.KeyCount === 0) return callback();
 
     params = { Bucket: bucketName };
     params.Delete = { Objects: [] };


### PR DESCRIPTION
## Summary

- When using  an outputPath, only the files inside that outputPath are removed. This allows buckets with more than a project to only update the target project and avoid removing the others.
- When not using an ouputPath, since prefix is `''`, it works as before
- Fixed a bug where, when no files were present it showed an "XML Malformed" error when trying to delete them. The deploy worked anyway.